### PR TITLE
Update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,35 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-
   # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+      time: "10:00"
+      # Use Los Angeles Standard Time (UTC -07:00)
+      timezone: "America/Los_Angeles"
+    # Raise all npm pull requests with custom labels
+    labels:
+      - "github-actions"
+      - "dependencies"
 
   # Maintain dependencies for pipenv
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
+    open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+      time: "10:00"
+      # Use Los Angeles Standard Time (UTC -07:00)
+      timezone: "America/Los_Angeles"
+    # Raise all npm pull requests with custom labels
+    labels:
+      - "npm"
+      - "dependencies"
+    versioning-strategy: "increase"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,6 @@ updates:
       timezone: "America/Los_Angeles"
     # Raise all npm pull requests with custom labels
     labels:
-      - "npm"
+      - "pip"
       - "dependencies"
     versioning-strategy: "increase"


### PR DESCRIPTION
Dependabot is given the following updates:
- documentation page is now updated to the correct page, as the previous one is deprecated
- The pull request from Dependabot are now daily and at a regular schedule, and labels are created to add context to its pull requests